### PR TITLE
Embed Static Content in Compiled Binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,8 +95,6 @@ dependencies = [
  "tera",
  "thiserror 2.0.3",
  "tokio",
- "tower",
- "tower-http",
 ]
 
 [[package]]
@@ -745,12 +743,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -2067,19 +2059,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,31 +2069,6 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper 0.1.2",
  "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
- "mime",
- "mime_guess",
- "percent-encoding",
- "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler32"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "ahash"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -25,6 +43,12 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -59,12 +83,14 @@ dependencies = [
  "async-trait",
  "atrium-api",
  "axum",
+ "axum-embed",
  "color-eyre",
  "health",
  "http-body",
  "http-body-util",
  "jetstream-oxide",
  "lazy_static",
+ "rust-embed",
  "serde",
  "tera",
  "thiserror 2.0.3",
@@ -166,6 +192,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-embed"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "077959a7f8cf438676af90b483304528eb7e16eadadb7f44e9ada4f9dceb9e62"
+dependencies = [
+ "axum-core",
+ "chrono",
+ "http",
+ "mime_guess",
+ "rust-embed",
+ "tower-service",
 ]
 
 [[package]]
@@ -362,6 +402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -395,6 +444,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 
 [[package]]
 name = "data-encoding"
@@ -627,6 +682,16 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -922,6 +987,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "include-flate"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df49c16750695486c1f34de05da5b7438096156466e7f76c38fcdf285cf0113e"
+dependencies = [
+ "include-flate-codegen",
+ "lazy_static",
+ "libflate",
+]
+
+[[package]]
+name = "include-flate-codegen"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c5b246c6261be723b85c61ecf87804e8ea4a35cb68be0ff282ed84b95ffe7d7"
+dependencies = [
+ "libflate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,7 +1022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -1014,6 +1102,30 @@ name = "libc"
 version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+
+[[package]]
+name = "libflate"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
+dependencies = [
+ "adler32",
+ "core2",
+ "crc32fast",
+ "dary_heap",
+ "libflate_lz77",
+]
+
+[[package]]
+name = "libflate_lz77"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
+dependencies = [
+ "core2",
+ "hashbrown 0.14.5",
+ "rle-decode-fast",
+]
 
 [[package]]
 name = "libm"
@@ -1462,6 +1574,48 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rle-decode-fast"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
+
+[[package]]
+name = "rust-embed"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
+dependencies = [
+ "include-flate",
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.90",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
+dependencies = [
+ "globset",
+ "sha2",
+ "walkdir",
+]
 
 [[package]]
 name = "rustc-demangle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "AGPL-3.0"
 
 [dependencies]
 axum = "0.7.5"
+axum-embed = "0.1.0"
 async-trait = "0.1.83"
 atrium-api = "0.24.8"
 color-eyre = "0.6.2"
@@ -16,6 +17,7 @@ http-body = "1.0.1"
 http-body-util = "0.1.2"
 jetstream-oxide = "0.1.0"
 lazy_static = "1.4.0"
+rust-embed = { version = "8.5.0", features = ["compression", "debug-embed", "include-exclude"] }
 serde = { version = "1.0.195", features = ["derive"] }
 tera = "1.19.1"
 thiserror = "2.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,3 @@ serde = { version = "1.0.195", features = ["derive"] }
 tera = "1.19.1"
 thiserror = "2.0.0"
 tokio = { version = "1.41.1", features = ["full", "sync"] }
-tower = "0.5.1"
-tower-http = { version = "0.6.2", features = ["fs"] }

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,5 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
  
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /app/src/web/static /usr/local/bin/atbb/src/web/static
-COPY --from=builder /app/src/web/templates /usr/local/bin/atbb/src/web/templates
-COPY --from=builder /usr/local/cargo/bin/atbb /usr/local/bin/atbb/atbb
-CMD [ "/usr/local/bin/atbb/atbb" ]
+COPY --from=builder /usr/local/cargo/bin/atbb /usr/local/bin/atbb
+CMD [ "/usr/local/bin/atbb" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
  
 FROM debian:bullseye-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /usr/local/cargo/bin/atbb /usr/local/bin/atbb
-CMD [ "/usr/local/bin/atbb" ]
+COPY --from=builder /app/src/web/static /usr/local/bin/atbb/src/web/static
+COPY --from=builder /app/src/web/templates /usr/local/bin/atbb/src/web/templates
+COPY --from=builder /usr/local/cargo/bin/atbb /usr/local/bin/atbb/atbb
+CMD [ "/usr/local/bin/atbb/atbb" ]

--- a/src/web/pages.rs
+++ b/src/web/pages.rs
@@ -36,14 +36,14 @@ lazy_static! {
                 Ok(c) => c,
                 Err(e) => {
                     println!("Template parsing error(s): {e}");
-                    panic!();
+                    panic!("Template parsing error(s): {e}");
                 }
             };
             match tera.add_raw_template(&path, contents) {
                 Ok(t) => t,
                 Err(e) => {
                     println!("Template parsing error(s): {e}");
-                    panic!();
+                    panic!("Template parsing error(s): {e}");
                 }
             }
         }

--- a/src/web/pages.rs
+++ b/src/web/pages.rs
@@ -1,29 +1,52 @@
 //! Routes to serve HTML pages
 
 use axum::{routing::get, Router};
+use axum_embed::ServeEmbed;
 use lazy_static::lazy_static;
+use rust_embed::Embed;
 use tera::Tera;
-use tower_http::services::ServeDir;
 
 use crate::web::WebState;
 
 mod index;
 
+#[derive(Embed, Clone)]
+#[folder = "src/web/static"]
+#[include = "*.css"]
+struct StaticAssets;
+
+#[derive(Embed)]
+#[folder = "src/web/templates"]
+#[include = "*.html"]
+struct Templates;
+
 pub fn compose(app_state: WebState) -> Router {
     Router::new()
         .route("/", get(index::index))
         .with_state(app_state)
-        .nest_service("/static", ServeDir::new("src/web/static"))
+        .nest_service("/static", ServeEmbed::<StaticAssets>::new())
 }
 
 lazy_static! {
     pub static ref TEMPLATES: Tera = {
-        match Tera::new("src/web/templates/**/*") {
-            Ok(t) => t,
-            Err(e) => {
-                println!("Template parsing error(s): {e}");
-                ::std::process::exit(1);
+        let mut tera = Tera::default();
+        for path in Templates::iter() {
+            let file = Templates::get(&path).unwrap();
+            let contents = match std::str::from_utf8(file.data.as_ref()) {
+                Ok(c) => c,
+                Err(e) => {
+                    println!("Template parsing error(s): {e}");
+                    ::std::process::exit(1);
+                }
+            };
+            match tera.add_raw_template(&path, contents) {
+                Ok(t) => t,
+                Err(e) => {
+                    println!("Template parsing error(s): {e}");
+                    ::std::process::exit(1);
+                }
             }
-        }
+        };
+        tera
     };
 }

--- a/src/web/pages.rs
+++ b/src/web/pages.rs
@@ -36,17 +36,17 @@ lazy_static! {
                 Ok(c) => c,
                 Err(e) => {
                     println!("Template parsing error(s): {e}");
-                    ::std::process::exit(1);
+                    panic!();
                 }
             };
             match tera.add_raw_template(&path, contents) {
                 Ok(t) => t,
                 Err(e) => {
                     println!("Template parsing error(s): {e}");
-                    ::std::process::exit(1);
+                    panic!();
                 }
             }
-        };
+        }
         tera
     };
 }


### PR DESCRIPTION
This PR makes the necessary changes to embed static content in the compiled binary so that we do not need to be otherwise concerned with copying the assets to a place where the final executable is able to reach them.

This is achieved with:
- [rust-embed](https://git.sr.ht/~pyrossh/rust-embed) - a library that uses a macro to embed static content into the compiled binary
- [axum-embed](https://github.com/informationsea/axum-embed) - a library conveniently wrapping rust-embed and providing a means of serving embedded content